### PR TITLE
Avoid panic when no operation context

### DIFF
--- a/gqlgen.go
+++ b/gqlgen.go
@@ -55,6 +55,10 @@ func (a Tracer) Validate(_ graphql.ExecutableSchema) error {
 }
 
 func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	if !graphql.HasOperationContext(ctx) {
+		return next(ctx)
+	}
+
 	ctx, span := a.tracer.Start(ctx, operationName(ctx), oteltrace.WithSpanKind(oteltrace.SpanKindServer))
 	defer span.End()
 	if !span.IsRecording() {


### PR DESCRIPTION
The middleware panics when it receives a HTTP request with invalid body (for example, invalid JSON).

This PR fixes it by skipping `InterceptResponse` when `ctx` has no operation context of gqlgen.

According to a comment from `HasOperationContext`:

>HasOperationContext checks if the given context is part of an ongoing operation
>
>Some errors can happen outside of an operation, eg json unmarshal errors.

# Before

```
% curl -XPOST -H 'content-type: application/json' -d '' http://localhost:8080/query
{"errors":[{"message":"internal system error"}],"data":null}
```

```
% go run server.go
2023/05/16 21:36:51 connect to http://localhost:8080/ for GraphQL playground
missing operation context

goroutine 18 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.20.3/libexec/src/runtime/debug/stack.go:24 +0x64
runtime/debug.PrintStack()
        /opt/homebrew/Cellar/go/1.20.3/libexec/src/runtime/debug/stack.go:16 +0x1c
github.com/99designs/gqlgen/graphql.DefaultRecover({0x140000bd1c8?, 0x10178d940?}, {0x10141c660?, 0x1014aa5c8?})
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/recovery.go:17 +0x78
github.com/99designs/gqlgen/graphql/executor.(*Executor).PresentRecoveredError(0x140000b7ae0, {0x1014af208, 0x140002b26c0}, {0x10141c660?, 0x1014aa5c8?})
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/executor/executor.go:156 +0x48
github.com/99designs/gqlgen/graphql/handler.(*Server).ServeHTTP.func1()
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/handler/server.go:104 +0x94
panic({0x10141c660, 0x1014aa5c8})
        /opt/homebrew/Cellar/go/1.20.3/libexec/src/runtime/panic.go:884 +0x204
github.com/99designs/gqlgen/graphql.GetOperationContext({0x1014af208?, 0x140002b2750?})
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/context_operation.go:65 +0x7c
github.com/ravilushqa/otelgqlgen.operationName({0x1014af208, 0x140002b2750})
        /Users/utgwkk/ghq/github.com/utgwkk/otelgqlgen/gqlgen.go:173 +0x24
github.com/ravilushqa/otelgqlgen.Tracer.InterceptResponse({{0x0, 0x0}, {0x1014abfa8, 0x140002afd80}, 0x1014a9428, 0x1014a9420}, {0x1014af208, 0x140002b2750}, 0x140000a0390)
        /Users/utgwkk/ghq/github.com/utgwkk/otelgqlgen/gqlgen.go:58 +0x5c
github.com/99designs/gqlgen/graphql/executor.processExtensions.func6({0x1014af208, 0x140002b2750}, 0x1014a93c0)
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/executor/extensions.go:91 +0xac
github.com/99designs/gqlgen/graphql/executor.(*Executor).DispatchError(0x140000b7ae0, {0x1014af208, 0x140002b26c0}, {0x140000a62b0, 0x1, 0x100f8c80c?})
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/executor/executor.go:144 +0x10c
github.com/99designs/gqlgen/graphql/handler/transport.POST.Do({0x1014af160?}, {0x1014aef50?, 0x140002b00e0}, 0x140000fa700, {0x1014aec80, 0x140000b7ae0})
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/handler/transport/http_post.go:76 +0x560
github.com/99designs/gqlgen/graphql/handler.(*Server).ServeHTTP(0x140000c09c0, {0x1014aef50, 0x140002b00e0}, 0x140000fa700)
        /Users/utgwkk/go/pkg/mod/github.com/99designs/gqlgen@v0.17.31/graphql/handler/server.go:121 +0x1fc
net/http.(*ServeMux).ServeHTTP(0x0?, {0x1014aef50, 0x140002b00e0}, 0x140000fa600)
        /opt/homebrew/Cellar/go/1.20.3/libexec/src/net/http/server.go:2500 +0x140
net/http.serverHandler.ServeHTTP({0x140002b25a0?}, {0x1014aef50, 0x140002b00e0}, 0x140000fa600)
        /opt/homebrew/Cellar/go/1.20.3/libexec/src/net/http/server.go:2936 +0x2d8
net/http.(*conn).serve(0x14000116240, {0x1014af208, 0x140002b24b0})
        /opt/homebrew/Cellar/go/1.20.3/libexec/src/net/http/server.go:1995 +0x560
created by net/http.(*Server).Serve
        /opt/homebrew/Cellar/go/1.20.3/libexec/src/net/http/server.go:3089 +0x520
2023/05/16 21:36:52 http: superfluous response.WriteHeader call from github.com/99designs/gqlgen/graphql/handler.(*Server).ServeHTTP.func1 (server.go:108)
```

# With this PR

```
% curl -XPOST -H 'content-type: application/json' -d '' http://localhost:8080/query
{"errors":[{"message":"json request body could not be decoded: EOF body:"}],"data":null}
```

(server has no error message)