### PR TITLE
Fall back to `Operation.Name` if `OperationName` is empty

### DIFF
--- a/gqlgen.go
+++ b/gqlgen.go
@@ -183,6 +183,9 @@ func operationName(ctx context.Context) string {
 	if opName := opContext.OperationName; opName != "" {
 		return opName
 	}
+	if opContext.Operation != nil && opContext.Operation.Name != "" {
+		return opContext.Operation.Name
+	}
 	return GetOperationName(ctx)
 }
 


### PR DESCRIPTION
This pull request aims to address an issue I've noticed in my local environment where the `OperationContext.OperationName` consistently appears empty, while the `OperationContext.Operation.Name` is populated. After some investigation, I was unable to discern the differences between `OperationContext.OperationName` and `OperationContext.Operation.Name`.

In order to address this situation and ensure the functionality isn't disrupted due to an empty `OperationContext.OperationName`, I've made modifications to the library to implement a fallback mechanism. With this PR, if `OperationContext.OperationName` is found to be empty, the library will fall back to using `OperationContext.Operation.Name`.

This solution should prevent potential disruption or loss of information caused by the issue, and help the library function more robustly in various environments. 

---

UPDATE: The `OperationContext.OperationName` is the string specified in the `operationName` parameter, whereas `OperationContext.Operation.Name` is the name specified directly in the GraphQL query (i.e., `query HERE { ... }`).

