### PR TITLE
Extract response handling to customizable functions

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ package otelgqlgen
 
 import (
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -26,17 +27,27 @@ type SpanKindSelectorFunc func(operationName string) trace.SpanKind
 
 // config is used to configure the mongo tracer.
 type config struct {
-	TracerProvider             trace.TracerProvider
-	Tracer                     trace.Tracer
-	ComplexityExtensionName    string
-	RequestVariablesBuilder    RequestVariablesBuilderFunc
-	ShouldCreateSpanFromFields FieldsPredicateFunc
-	SpanKindSelectorFunc       SpanKindSelectorFunc
+	TracerProvider                     trace.TracerProvider
+	Tracer                             trace.Tracer
+	ComplexityExtensionName            string
+	RequestVariablesBuilder            RequestVariablesBuilderFunc
+	ShouldCreateSpanFromFields         FieldsPredicateFunc
+	SpanKindSelectorFunc               SpanKindSelectorFunc
+	InterceptResponseResultHandlerFunc InterceptResponseResultHandlerFunc
+	InterceptFieldsResultHanderFunc    InterceptFieldsResultHanderFunc
 }
 
 // RequestVariablesBuilderFunc is the signature of the function
 // used to build the request variables attributes.
 type RequestVariablesBuilderFunc func(requestVariables map[string]interface{}) []attribute.KeyValue
+
+// InterceptResponseResultHandlerFunc is the signature of the function
+// used to intercept and handle GraphQL response results before they are returned.
+type InterceptResponseResultHandlerFunc func(resp *graphql.Response, span trace.Span) *graphql.Response
+
+// InterceptFieldsResultHanderFunc is the signature of the function
+// used to intercept and handle GraphQL field-level results and errors during execution.
+type InterceptFieldsResultHanderFunc func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error)
 
 // Option specifies instrumentation configuration options.
 type Option interface {
@@ -93,5 +104,21 @@ func WithCreateSpanFromFields(predicate FieldsPredicateFunc) Option {
 func WithSpanKindSelector(spanKindSelector SpanKindSelectorFunc) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.SpanKindSelectorFunc = spanKindSelector
+	})
+}
+
+// WithInterceptResponseResultHandlerFunc allows specifying a custom function
+// to intercept and handle GraphQL response results before they are returned.
+func WithInterceptResponseResultHandlerFunc(handler InterceptResponseResultHandlerFunc) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.InterceptResponseResultHandlerFunc = handler
+	})
+}
+
+// WithInterceptFieldsResultHandlerFunc allows specifying a custom function
+// to intercept and handle GraphQL field-level results and errors during execution.
+func WithInterceptFieldsResultHandlerFunc(handler InterceptFieldsResultHanderFunc) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.InterceptFieldsResultHanderFunc = handler
 	})
 }

--- a/gqlgen.go
+++ b/gqlgen.go
@@ -20,10 +20,12 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	otelcontrib "go.opentelemetry.io/contrib"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -35,11 +37,13 @@ const (
 
 // Tracer is a GraphQL extension that traces GraphQL requests.
 type Tracer struct {
-	complexityExtensionName     string
-	tracer                      oteltrace.Tracer
-	requestVariablesBuilderFunc RequestVariablesBuilderFunc
-	shouldCreateSpanFromFields  FieldsPredicateFunc
-	spanKindSelector            SpanKindSelectorFunc
+	complexityExtensionName            string
+	tracer                             oteltrace.Tracer
+	requestVariablesBuilderFunc        RequestVariablesBuilderFunc
+	shouldCreateSpanFromFields         FieldsPredicateFunc
+	spanKindSelector                   SpanKindSelectorFunc
+	interceptResponseResultHandlerFunc InterceptResponseResultHandlerFunc
+	interceptFieldsResultHanderFunc    InterceptFieldsResultHanderFunc
 }
 
 var _ interface {
@@ -58,7 +62,6 @@ func (a Tracer) Validate(_ graphql.ExecutableSchema) error {
 	return nil
 }
 
-// InterceptResponse intercepts the incoming request.
 func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
 	if !graphql.HasOperationContext(ctx) {
 		return next(ctx)
@@ -99,15 +102,8 @@ func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	}
 
 	resp := next(ctx)
-	if resp != nil && len(resp.Errors) > 0 {
-		span.SetStatus(codes.Error, resp.Errors.Error())
-		span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
-		span.SetAttributes(ResolverErrors(resp.Errors)...)
-	} else {
-		span.SetStatus(codes.Ok, "Finished successfully")
-	}
 
-	return resp
+	return a.interceptResponseResultHandlerFunc(resp, span)
 }
 
 // InterceptField intercepts the incoming request.
@@ -136,17 +132,9 @@ func (a Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	span.SetAttributes(ResolverArgs(fc.Field.Arguments)...)
 
 	resp, err := next(ctx)
-
 	errList := graphql.GetFieldErrors(ctx, fc)
-	if len(errList) != 0 {
-		span.SetStatus(codes.Error, errList.Error())
-		span.RecordError(fmt.Errorf("graphql field errors: %v", errList.Error()))
-		span.SetAttributes(ResolverErrors(errList)...)
-	} else {
-		span.SetStatus(codes.Ok, "Finished successfully")
-	}
 
-	return resp, err
+	return a.interceptFieldsResultHanderFunc(resp, err, errList, span)
 }
 
 // Middleware sets up a handler to start tracing the incoming
@@ -169,6 +157,12 @@ func Middleware(opts ...Option) Tracer {
 	if cfg.SpanKindSelectorFunc == nil {
 		cfg.SpanKindSelectorFunc = alwaysServer()
 	}
+	if cfg.InterceptResponseResultHandlerFunc == nil {
+		cfg.InterceptResponseResultHandlerFunc = defaultInterceptResponseResultHandler()
+	}
+	if cfg.InterceptFieldsResultHanderFunc == nil {
+		cfg.InterceptFieldsResultHanderFunc = defaultInterceptFieldsResultHander()
+	}
 
 	tracer := cfg.TracerProvider.Tracer(
 		tracerName,
@@ -176,10 +170,12 @@ func Middleware(opts ...Option) Tracer {
 	)
 
 	return Tracer{
-		tracer:                      tracer,
-		requestVariablesBuilderFunc: cfg.RequestVariablesBuilder,
-		shouldCreateSpanFromFields:  cfg.ShouldCreateSpanFromFields,
-		spanKindSelector:            cfg.SpanKindSelectorFunc,
+		tracer:                             tracer,
+		requestVariablesBuilderFunc:        cfg.RequestVariablesBuilder,
+		shouldCreateSpanFromFields:         cfg.ShouldCreateSpanFromFields,
+		spanKindSelector:                   cfg.SpanKindSelectorFunc,
+		interceptResponseResultHandlerFunc: cfg.InterceptResponseResultHandlerFunc,
+		interceptFieldsResultHanderFunc:    cfg.InterceptFieldsResultHanderFunc,
 	}
 
 }
@@ -194,6 +190,33 @@ func alwaysTrue() FieldsPredicateFunc {
 func alwaysServer() SpanKindSelectorFunc {
 	return func(_ string) oteltrace.SpanKind {
 		return oteltrace.SpanKindServer
+	}
+}
+
+func defaultInterceptResponseResultHandler() InterceptResponseResultHandlerFunc {
+	return func(resp *graphql.Response, span trace.Span) *graphql.Response {
+		if resp != nil && len(resp.Errors) > 0 {
+			span.SetStatus(codes.Error, resp.Errors.Error())
+			span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
+			span.SetAttributes(ResolverErrors(resp.Errors)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+		return resp
+	}
+}
+
+func defaultInterceptFieldsResultHander() InterceptFieldsResultHanderFunc {
+	return func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
 	}
 }
 

--- a/gqlgen_test.go
+++ b/gqlgen_test.go
@@ -506,6 +506,166 @@ func TestWithSpanKindSelector(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 }
 
+func TestChildSpanWithInterceptFieldsResultHandler(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServer(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptFieldsResultHandlerFunc(func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		// Set custom span attribute
+		span.SetAttributes(attribute.String("custom.field.result", "intercepted"))
+
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Ok, trace.SpanKindServer)
+
+	// Verify custom attribute was set on field span (first span)
+	spans := spanRecorder.Ended()
+	fieldSpan := spans[0]
+	attributes := fieldSpan.Attributes()
+	var foundCustomAttribute bool
+	for _, a := range attributes {
+		if a.Key == "custom.field.result" {
+			foundCustomAttribute = true
+			assert.Equal(t, "intercepted", a.Value.AsString())
+		}
+	}
+	assert.True(t, foundCustomAttribute, "custom field result attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestChildSpanWithInterceptFieldsResultHandlerWithError(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServerError(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptFieldsResultHandlerFunc(func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		// Set custom span attribute
+		span.SetAttributes(attribute.String("custom.field.error", "error_intercepted"))
+
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Error, trace.SpanKindServer)
+
+	// Verify custom attribute was set on field span (first span)
+	spans := spanRecorder.Ended()
+	fieldSpan := spans[0]
+	attributes := fieldSpan.Attributes()
+	var foundCustomAttribute bool
+	for _, a := range attributes {
+		if a.Key == "custom.field.error" {
+			foundCustomAttribute = true
+			assert.Equal(t, "error_intercepted", a.Value.AsString())
+		}
+	}
+	assert.True(t, foundCustomAttribute, "custom field error attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestChildSpanWithInterceptFieldsResultHandlerModifyResponse(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServer(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptFieldsResultHandlerFunc(func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		// Set custom span attributes based on response
+		if gqlResp, ok := resp.(*graphql.Response); ok && gqlResp != nil {
+			span.SetAttributes(attribute.String("custom.response.type", "graphql_response"))
+			span.SetAttributes(attribute.Bool("custom.response.has_data", len(gqlResp.Data) > 0))
+		}
+
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Ok, trace.SpanKindServer)
+
+	// Verify custom attributes were set on field span (first span)
+	spans := spanRecorder.Ended()
+	fieldSpan := spans[0]
+	attributes := fieldSpan.Attributes()
+
+	var foundResponseType, foundHasData bool
+	for _, a := range attributes {
+		if a.Key == "custom.response.type" {
+			foundResponseType = true
+			assert.Equal(t, "graphql_response", a.Value.AsString())
+		}
+		if a.Key == "custom.response.has_data" {
+			foundHasData = true
+			assert.Equal(t, true, a.Value.AsBool())
+		}
+	}
+
+	assert.True(t, foundResponseType, "custom response type attribute should be found")
+	assert.True(t, foundHasData, "custom response has_data attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
 // newMockServer provides a server for use in resolver tests that isn't relying on generated code.
 // It isn't a perfect reproduction of a generated server, but it aims to be good enough to
 // test the handler package without relying on codegen.


### PR DESCRIPTION
This PR adds two configuration fields:
 - `InterceptResponseResultHandlerFunc`
 - `InterceptFieldsResultHanderFunc`

If not set, those handlers will use the default logic used in `InterceptResponse` and `InterceptField`. 

The addition of those handler functions will allow for better control over how responses are handled. 
E.g., setting custom attributes based on the error. 
```go
otelgqlgen.WithInterceptResponseResultHandlerFunc(func(resp *graphql.Response, span oteltrace.Span) *graphql.Response {
  if resp != nil && len(resp.Errors) > 0 {
    span.SetStatus(codes.Error, resp.Errors.Error())
    span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
    span.SetAttributes(otelgqlgen.ResolverErrors(resp.Errors)...)

    hasAPIErrors := false
    for _, err := range resp.Errors {
      if !utils.IsAPIError(err) {
        hasAPIErrors = true
      }
    }
    span.SetAttributes(
      withAPIErrorAttrKey.Bool(hasAPIErrors),
    )

  } else {
    span.SetStatus(codes.Ok, "Finished successfully")
  }
  return resp
})

```
