### PR TITLE
Ddomurad/extract response handlers to customizable functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ otelgqlgen provides several options to customize the tracing behavior:
 - `WithRequestVariablesAttributesBuilder(builder)`: Specifies a custom function to build the attributes for the request variables.
 - `WithoutVariables()`: Disables the variables attributes.
 - `WithCreateSpanFromFields(predicate)`: Specifies a custom function to control whether a span should be created based on the GraphQL context fields.
+- `WithInterceptResponseResultHandlerFunc(handler)`: Specifies a custom function to intercept and handle GraphQL response results before they are returned.
+- `WithInterceptFieldsResultHandlerFunc(handler)`: Specifies a custom function to intercept and handle GraphQL field-level results and errors during execution.
 
 ## Example
 

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ package otelgqlgen
 
 import (
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -26,17 +27,27 @@ type SpanKindSelectorFunc func(operationName string) trace.SpanKind
 
 // config is used to configure the mongo tracer.
 type config struct {
-	TracerProvider             trace.TracerProvider
-	Tracer                     trace.Tracer
-	ComplexityExtensionName    string
-	RequestVariablesBuilder    RequestVariablesBuilderFunc
-	ShouldCreateSpanFromFields FieldsPredicateFunc
-	SpanKindSelectorFunc       SpanKindSelectorFunc
+	TracerProvider                     trace.TracerProvider
+	Tracer                             trace.Tracer
+	ComplexityExtensionName            string
+	RequestVariablesBuilder            RequestVariablesBuilderFunc
+	ShouldCreateSpanFromFields         FieldsPredicateFunc
+	SpanKindSelectorFunc               SpanKindSelectorFunc
+	InterceptResponseResultHandlerFunc InterceptResponseResultHandlerFunc
+	InterceptFieldsResultHanderFunc    InterceptFieldsResultHanderFunc
 }
 
 // RequestVariablesBuilderFunc is the signature of the function
 // used to build the request variables attributes.
 type RequestVariablesBuilderFunc func(requestVariables map[string]interface{}) []attribute.KeyValue
+
+// InterceptResponseResultHandlerFunc is the signature of the function
+// used to intercept and handle GraphQL response results before they are returned.
+type InterceptResponseResultHandlerFunc func(resp *graphql.Response, span trace.Span) *graphql.Response
+
+// InterceptFieldsResultHanderFunc is the signature of the function
+// used to intercept and handle GraphQL field-level results and errors during execution.
+type InterceptFieldsResultHanderFunc func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error)
 
 // Option specifies instrumentation configuration options.
 type Option interface {
@@ -93,5 +104,21 @@ func WithCreateSpanFromFields(predicate FieldsPredicateFunc) Option {
 func WithSpanKindSelector(spanKindSelector SpanKindSelectorFunc) Option {
 	return optionFunc(func(cfg *config) {
 		cfg.SpanKindSelectorFunc = spanKindSelector
+	})
+}
+
+// WithInterceptResponseResultHandlerFunc allows specifying a custom function
+// to intercept and handle GraphQL response results before they are returned.
+func WithInterceptResponseResultHandlerFunc(handler InterceptResponseResultHandlerFunc) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.InterceptResponseResultHandlerFunc = handler
+	})
+}
+
+// WithInterceptFieldsResultHandlerFunc allows specifying a custom function
+// to intercept and handle GraphQL field-level results and errors during execution.
+func WithInterceptFieldsResultHandlerFunc(handler InterceptFieldsResultHanderFunc) Option {
+	return optionFunc(func(cfg *config) {
+		cfg.InterceptFieldsResultHanderFunc = handler
 	})
 }

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ type config struct {
 	ShouldCreateSpanFromFields         FieldsPredicateFunc
 	SpanKindSelectorFunc               SpanKindSelectorFunc
 	InterceptResponseResultHandlerFunc InterceptResponseResultHandlerFunc
-	InterceptFieldsResultHanderFunc    InterceptFieldsResultHanderFunc
+	InterceptFieldsResultHandlerFunc   InterceptFieldsResultHandlerFunc
 }
 
 // RequestVariablesBuilderFunc is the signature of the function
@@ -45,9 +45,9 @@ type RequestVariablesBuilderFunc func(requestVariables map[string]interface{}) [
 // used to intercept and handle GraphQL response results before they are returned.
 type InterceptResponseResultHandlerFunc func(resp *graphql.Response, span trace.Span) *graphql.Response
 
-// InterceptFieldsResultHanderFunc is the signature of the function
+// InterceptFieldsResultHandlerFunc is the signature of the function
 // used to intercept and handle GraphQL field-level results and errors during execution.
-type InterceptFieldsResultHanderFunc func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error)
+type InterceptFieldsResultHandlerFunc func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error)
 
 // Option specifies instrumentation configuration options.
 type Option interface {
@@ -117,8 +117,8 @@ func WithInterceptResponseResultHandlerFunc(handler InterceptResponseResultHandl
 
 // WithInterceptFieldsResultHandlerFunc allows specifying a custom function
 // to intercept and handle GraphQL field-level results and errors during execution.
-func WithInterceptFieldsResultHandlerFunc(handler InterceptFieldsResultHanderFunc) Option {
+func WithInterceptFieldsResultHandlerFunc(handler InterceptFieldsResultHandlerFunc) Option {
 	return optionFunc(func(cfg *config) {
-		cfg.InterceptFieldsResultHanderFunc = handler
+		cfg.InterceptFieldsResultHandlerFunc = handler
 	})
 }

--- a/gqlgen.go
+++ b/gqlgen.go
@@ -43,7 +43,7 @@ type Tracer struct {
 	shouldCreateSpanFromFields         FieldsPredicateFunc
 	spanKindSelector                   SpanKindSelectorFunc
 	interceptResponseResultHandlerFunc InterceptResponseResultHandlerFunc
-	interceptFieldsResultHanderFunc    InterceptFieldsResultHanderFunc
+	interceptFieldsResultHandlerFunc   InterceptFieldsResultHandlerFunc
 }
 
 var _ interface {
@@ -134,7 +134,7 @@ func (a Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	resp, err := next(ctx)
 	errList := graphql.GetFieldErrors(ctx, fc)
 
-	return a.interceptFieldsResultHanderFunc(resp, err, errList, span)
+	return a.interceptFieldsResultHandlerFunc(resp, err, errList, span)
 }
 
 // Middleware sets up a handler to start tracing the incoming
@@ -160,8 +160,8 @@ func Middleware(opts ...Option) Tracer {
 	if cfg.InterceptResponseResultHandlerFunc == nil {
 		cfg.InterceptResponseResultHandlerFunc = defaultInterceptResponseResultHandler()
 	}
-	if cfg.InterceptFieldsResultHanderFunc == nil {
-		cfg.InterceptFieldsResultHanderFunc = defaultInterceptFieldsResultHander()
+	if cfg.InterceptFieldsResultHandlerFunc == nil {
+		cfg.InterceptFieldsResultHandlerFunc = defaultInterceptFieldsResultHandler()
 	}
 
 	tracer := cfg.TracerProvider.Tracer(
@@ -175,7 +175,7 @@ func Middleware(opts ...Option) Tracer {
 		shouldCreateSpanFromFields:         cfg.ShouldCreateSpanFromFields,
 		spanKindSelector:                   cfg.SpanKindSelectorFunc,
 		interceptResponseResultHandlerFunc: cfg.InterceptResponseResultHandlerFunc,
-		interceptFieldsResultHanderFunc:    cfg.InterceptFieldsResultHanderFunc,
+		interceptFieldsResultHandlerFunc:   cfg.InterceptFieldsResultHandlerFunc,
 	}
 
 }
@@ -206,7 +206,7 @@ func defaultInterceptResponseResultHandler() InterceptResponseResultHandlerFunc 
 	}
 }
 
-func defaultInterceptFieldsResultHander() InterceptFieldsResultHanderFunc {
+func defaultInterceptFieldsResultHandler() InterceptFieldsResultHandlerFunc {
 	return func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
 		if len(fieldErrList) != 0 {
 			span.SetStatus(codes.Error, fieldErrList.Error())

--- a/gqlgen.go
+++ b/gqlgen.go
@@ -20,10 +20,12 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	otelcontrib "go.opentelemetry.io/contrib"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -35,11 +37,13 @@ const (
 
 // Tracer is a GraphQL extension that traces GraphQL requests.
 type Tracer struct {
-	complexityExtensionName     string
-	tracer                      oteltrace.Tracer
-	requestVariablesBuilderFunc RequestVariablesBuilderFunc
-	shouldCreateSpanFromFields  FieldsPredicateFunc
-	spanKindSelector            SpanKindSelectorFunc
+	complexityExtensionName            string
+	tracer                             oteltrace.Tracer
+	requestVariablesBuilderFunc        RequestVariablesBuilderFunc
+	shouldCreateSpanFromFields         FieldsPredicateFunc
+	spanKindSelector                   SpanKindSelectorFunc
+	interceptResponseResultHandlerFunc InterceptResponseResultHandlerFunc
+	interceptFieldsResultHanderFunc    InterceptFieldsResultHanderFunc
 }
 
 var _ interface {
@@ -58,7 +62,6 @@ func (a Tracer) Validate(_ graphql.ExecutableSchema) error {
 	return nil
 }
 
-// InterceptResponse intercepts the incoming request.
 func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
 	if !graphql.HasOperationContext(ctx) {
 		return next(ctx)
@@ -99,15 +102,8 @@ func (a Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	}
 
 	resp := next(ctx)
-	if resp != nil && len(resp.Errors) > 0 {
-		span.SetStatus(codes.Error, resp.Errors.Error())
-		span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
-		span.SetAttributes(ResolverErrors(resp.Errors)...)
-	} else {
-		span.SetStatus(codes.Ok, "Finished successfully")
-	}
 
-	return resp
+	return a.interceptResponseResultHandlerFunc(resp, span)
 }
 
 // InterceptField intercepts the incoming request.
@@ -136,17 +132,9 @@ func (a Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	span.SetAttributes(ResolverArgs(fc.Field.Arguments)...)
 
 	resp, err := next(ctx)
-
 	errList := graphql.GetFieldErrors(ctx, fc)
-	if len(errList) != 0 {
-		span.SetStatus(codes.Error, errList.Error())
-		span.RecordError(fmt.Errorf("graphql field errors: %v", errList.Error()))
-		span.SetAttributes(ResolverErrors(errList)...)
-	} else {
-		span.SetStatus(codes.Ok, "Finished successfully")
-	}
 
-	return resp, err
+	return a.interceptFieldsResultHanderFunc(resp, err, errList, span)
 }
 
 // Middleware sets up a handler to start tracing the incoming
@@ -169,6 +157,12 @@ func Middleware(opts ...Option) Tracer {
 	if cfg.SpanKindSelectorFunc == nil {
 		cfg.SpanKindSelectorFunc = alwaysServer()
 	}
+	if cfg.InterceptResponseResultHandlerFunc == nil {
+		cfg.InterceptResponseResultHandlerFunc = defaultInterceptResponseResultHandler()
+	}
+	if cfg.InterceptFieldsResultHanderFunc == nil {
+		cfg.InterceptFieldsResultHanderFunc = defaultInterceptFieldsResultHander()
+	}
 
 	tracer := cfg.TracerProvider.Tracer(
 		tracerName,
@@ -176,10 +170,12 @@ func Middleware(opts ...Option) Tracer {
 	)
 
 	return Tracer{
-		tracer:                      tracer,
-		requestVariablesBuilderFunc: cfg.RequestVariablesBuilder,
-		shouldCreateSpanFromFields:  cfg.ShouldCreateSpanFromFields,
-		spanKindSelector:            cfg.SpanKindSelectorFunc,
+		tracer:                             tracer,
+		requestVariablesBuilderFunc:        cfg.RequestVariablesBuilder,
+		shouldCreateSpanFromFields:         cfg.ShouldCreateSpanFromFields,
+		spanKindSelector:                   cfg.SpanKindSelectorFunc,
+		interceptResponseResultHandlerFunc: cfg.InterceptResponseResultHandlerFunc,
+		interceptFieldsResultHanderFunc:    cfg.InterceptFieldsResultHanderFunc,
 	}
 
 }
@@ -194,6 +190,33 @@ func alwaysTrue() FieldsPredicateFunc {
 func alwaysServer() SpanKindSelectorFunc {
 	return func(_ string) oteltrace.SpanKind {
 		return oteltrace.SpanKindServer
+	}
+}
+
+func defaultInterceptResponseResultHandler() InterceptResponseResultHandlerFunc {
+	return func(resp *graphql.Response, span trace.Span) *graphql.Response {
+		if resp != nil && len(resp.Errors) > 0 {
+			span.SetStatus(codes.Error, resp.Errors.Error())
+			span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
+			span.SetAttributes(ResolverErrors(resp.Errors)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+		return resp
+	}
+}
+
+func defaultInterceptFieldsResultHander() InterceptFieldsResultHanderFunc {
+	return func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
 	}
 }
 

--- a/gqlgen.go
+++ b/gqlgen.go
@@ -25,7 +25,6 @@ import (
 	otelcontrib "go.opentelemetry.io/contrib"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
@@ -194,7 +193,7 @@ func alwaysServer() SpanKindSelectorFunc {
 }
 
 func defaultInterceptResponseResultHandler() InterceptResponseResultHandlerFunc {
-	return func(resp *graphql.Response, span trace.Span) *graphql.Response {
+	return func(resp *graphql.Response, span oteltrace.Span) *graphql.Response {
 		if resp != nil && len(resp.Errors) > 0 {
 			span.SetStatus(codes.Error, resp.Errors.Error())
 			span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
@@ -207,7 +206,7 @@ func defaultInterceptResponseResultHandler() InterceptResponseResultHandlerFunc 
 }
 
 func defaultInterceptFieldsResultHandler() InterceptFieldsResultHandlerFunc {
-	return func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+	return func(resp interface{}, respErr error, fieldErrList gqlerror.List, span oteltrace.Span) (interface{}, error) {
 		if len(fieldErrList) != 0 {
 			span.SetStatus(codes.Error, fieldErrList.Error())
 			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))

--- a/gqlgen_test.go
+++ b/gqlgen_test.go
@@ -506,6 +506,166 @@ func TestWithSpanKindSelector(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 }
 
+func TestChildSpanWithInterceptFieldsResultHandler(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServer(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptFieldsResultHandlerFunc(func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		// Set custom span attribute
+		span.SetAttributes(attribute.String("custom.field.result", "intercepted"))
+
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Ok, trace.SpanKindServer)
+
+	// Verify custom attribute was set on field span (first span)
+	spans := spanRecorder.Ended()
+	fieldSpan := spans[0]
+	attributes := fieldSpan.Attributes()
+	var foundCustomAttribute bool
+	for _, a := range attributes {
+		if a.Key == "custom.field.result" {
+			foundCustomAttribute = true
+			assert.Equal(t, "intercepted", a.Value.AsString())
+		}
+	}
+	assert.True(t, foundCustomAttribute, "custom field result attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestChildSpanWithInterceptFieldsResultHandlerWithError(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServerError(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptFieldsResultHandlerFunc(func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		// Set custom span attribute
+		span.SetAttributes(attribute.String("custom.field.error", "error_intercepted"))
+
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Error, trace.SpanKindServer)
+
+	// Verify custom attribute was set on field span (first span)
+	spans := spanRecorder.Ended()
+	fieldSpan := spans[0]
+	attributes := fieldSpan.Attributes()
+	var foundCustomAttribute bool
+	for _, a := range attributes {
+		if a.Key == "custom.field.error" {
+			foundCustomAttribute = true
+			assert.Equal(t, "error_intercepted", a.Value.AsString())
+		}
+	}
+	assert.True(t, foundCustomAttribute, "custom field error attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestChildSpanWithInterceptFieldsResultHandlerModifyResponse(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServer(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptFieldsResultHandlerFunc(func(resp interface{}, respErr error, fieldErrList gqlerror.List, span trace.Span) (interface{}, error) {
+		// Set custom span attributes based on response
+		if gqlResp, ok := resp.(*graphql.Response); ok && gqlResp != nil {
+			span.SetAttributes(attribute.String("custom.response.type", "graphql_response"))
+			span.SetAttributes(attribute.Bool("custom.response.has_data", len(gqlResp.Data) > 0))
+		}
+
+		if len(fieldErrList) != 0 {
+			span.SetStatus(codes.Error, fieldErrList.Error())
+			span.RecordError(fmt.Errorf("graphql field errors: %v", fieldErrList.Error()))
+			span.SetAttributes(ResolverErrors(fieldErrList)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp, respErr
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Ok, trace.SpanKindServer)
+
+	// Verify custom attributes were set on field span (first span)
+	spans := spanRecorder.Ended()
+	fieldSpan := spans[0]
+	attributes := fieldSpan.Attributes()
+
+	var foundResponseType, foundHasData bool
+	for _, a := range attributes {
+		if a.Key == "custom.response.type" {
+			foundResponseType = true
+			assert.Equal(t, "graphql_response", a.Value.AsString())
+		}
+		if a.Key == "custom.response.has_data" {
+			foundHasData = true
+			assert.Equal(t, true, a.Value.AsBool())
+		}
+	}
+
+	assert.True(t, foundResponseType, "custom response type attribute should be found")
+	assert.True(t, foundHasData, "custom response has_data attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
 // newMockServer provides a server for use in resolver tests that isn't relying on generated code.
 // It isn't a perfect reproduction of a generated server, but it aims to be good enough to
 // test the handler package without relying on codegen.

--- a/gqlgen_test.go
+++ b/gqlgen_test.go
@@ -666,6 +666,184 @@ func TestChildSpanWithInterceptFieldsResultHandlerModifyResponse(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 }
 
+func TestChildSpanWithInterceptResponseResultHandler(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServer(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptResponseResultHandlerFunc(func(resp *graphql.Response, span trace.Span) *graphql.Response {
+		// Set custom span attribute
+		span.SetAttributes(attribute.String("custom.response.result", "intercepted"))
+
+		if resp != nil && len(resp.Errors) > 0 {
+			span.SetStatus(codes.Error, resp.Errors.Error())
+			span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
+			span.SetAttributes(ResolverErrors(resp.Errors)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Ok, trace.SpanKindServer)
+
+	// Verify custom attribute was set on response span (second span)
+	spans := spanRecorder.Ended()
+	responseSpan := spans[1]
+	attributes := responseSpan.Attributes()
+	var foundCustomAttribute bool
+	for _, a := range attributes {
+		if a.Key == "custom.response.result" {
+			foundCustomAttribute = true
+			assert.Equal(t, "intercepted", a.Value.AsString())
+		}
+	}
+	assert.True(t, foundCustomAttribute, "custom response result attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestChildSpanWithInterceptResponseResultHandlerWithError(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServerError(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptResponseResultHandlerFunc(func(resp *graphql.Response, span trace.Span) *graphql.Response {
+		// Set custom span attribute
+		span.SetAttributes(attribute.String("custom.response.error", "error_intercepted"))
+
+		if resp != nil && len(resp.Errors) > 0 {
+			span.SetStatus(codes.Error, resp.Errors.Error())
+			span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
+			span.SetAttributes(ResolverErrors(resp.Errors)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		return resp
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Error, trace.SpanKindServer)
+
+	// Verify custom attribute was set on response span (second span)
+	spans := spanRecorder.Ended()
+	responseSpan := spans[1]
+	attributes := responseSpan.Attributes()
+	var foundCustomAttribute bool
+	for _, a := range attributes {
+		if a.Key == "custom.response.error" {
+			foundCustomAttribute = true
+			assert.Equal(t, "error_intercepted", a.Value.AsString())
+		}
+	}
+	assert.True(t, foundCustomAttribute, "custom response error attribute should be found")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestChildSpanWithInterceptResponseResultHandlerModifyResponse(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	otel.SetTracerProvider(provider)
+
+	srv := newMockServer(func(ctx context.Context) (interface{}, error) {
+		span := trace.SpanContextFromContext(ctx)
+		if !span.IsValid() {
+			t.Fatalf("invalid span wrapping handler: %#v", span)
+		}
+		return &graphql.Response{Data: []byte(`{"name":"test"}`)}, nil
+	})
+	srv.Use(Middleware(WithInterceptResponseResultHandlerFunc(func(resp *graphql.Response, span trace.Span) *graphql.Response {
+		// Set custom span attributes based on response
+		if resp != nil {
+			span.SetAttributes(attribute.String("custom.response.type", "graphql_response"))
+			span.SetAttributes(attribute.Bool("custom.response.has_data", len(resp.Data) > 0))
+			span.SetAttributes(attribute.Int("custom.response.data_length", len(resp.Data)))
+		}
+
+		if resp != nil && len(resp.Errors) > 0 {
+			span.SetStatus(codes.Error, resp.Errors.Error())
+			span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
+			span.SetAttributes(ResolverErrors(resp.Errors)...)
+		} else {
+			span.SetStatus(codes.Ok, "Finished successfully")
+		}
+
+		// Modify response by adding custom extension
+		if resp != nil {
+			if resp.Extensions == nil {
+				resp.Extensions = make(map[string]interface{})
+			}
+			resp.Extensions["custom_interceptor"] = "response_modified"
+		}
+
+		return resp
+	})))
+
+	r := httptest.NewRequest("GET", "/foo?query={name}", nil)
+	w := httptest.NewRecorder()
+
+	srv.ServeHTTP(w, r)
+
+	testSpans(t, spanRecorder, namelessQueryName, codes.Ok, trace.SpanKindServer)
+
+	// Verify custom attributes were set on response span (second span)
+	spans := spanRecorder.Ended()
+	responseSpan := spans[1]
+	attributes := responseSpan.Attributes()
+
+	var foundResponseType, foundHasData, foundDataLength bool
+	for _, a := range attributes {
+		if a.Key == "custom.response.type" {
+			foundResponseType = true
+			assert.Equal(t, "graphql_response", a.Value.AsString())
+		}
+		if a.Key == "custom.response.has_data" {
+			foundHasData = true
+			assert.Equal(t, true, a.Value.AsBool())
+		}
+		if a.Key == "custom.response.data_length" {
+			foundDataLength = true
+			assert.Greater(t, a.Value.AsInt64(), int64(0))
+		}
+	}
+
+	assert.True(t, foundResponseType, "custom response type attribute should be found")
+	assert.True(t, foundHasData, "custom response has_data attribute should be found")
+	assert.True(t, foundDataLength, "custom response data_length attribute should be found")
+
+	// Verify response was modified
+	assert.Contains(t, w.Body.String(), "custom_interceptor")
+	assert.Contains(t, w.Body.String(), "response_modified")
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
 // newMockServer provides a server for use in resolver tests that isn't relying on generated code.
 // It isn't a perfect reproduction of a generated server, but it aims to be good enough to
 // test the handler package without relying on codegen.


### PR DESCRIPTION
This PR adds two configuration fields:
 - `InterceptResponseResultHandlerFunc`
 - `InterceptFieldsResultHanderFunc`

If not set, those handlers will use the default logic used in `InterceptResponse` and `InterceptField`. 

The addition of those handler functions will allow for better control over how responses are handled. 
E.g., setting custom attributes based on the error. 
```go
otelgqlgen.WithInterceptResponseResultHandlerFunc(func(resp *graphql.Response, span oteltrace.Span) *graphql.Response {
  if resp != nil && len(resp.Errors) > 0 {
    span.SetStatus(codes.Error, resp.Errors.Error())
    span.RecordError(fmt.Errorf("graphql response errors: %v", resp.Errors.Error()))
    span.SetAttributes(otelgqlgen.ResolverErrors(resp.Errors)...)

    hasAPIErrors := false
    for _, err := range resp.Errors {
      if !utils.IsAPIError(err) {
        hasAPIErrors = true
      }
    }
    span.SetAttributes(
      withAPIErrorAttrKey.Bool(hasAPIErrors),
    )

  } else {
    span.SetStatus(codes.Ok, "Finished successfully")
  }
  return resp
})

```
resolves #284